### PR TITLE
fix: disable broken demo mode in dev compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,7 +12,10 @@ services:
       - "5173:5173"
     environment:
       - NODE_ENV=development
-      - PUBLIC_DEMO_MODE=true
+      # Disabled: demo mode is broken (missing `demoUsers` map in login/+page.svelte,
+      # causes "ReferenceError: demoUsers is not defined"). Use a real registered
+      # account via --profile with-backend until the demo map is implemented.
+      - PUBLIC_DEMO_MODE=false
       - NPM_CONFIG_AUDIT=false
       - NPM_CONFIG_FUND=false
     volumes:


### PR DESCRIPTION
In local dev version, after creating my credentials when I try to log in I always get an error message. Claude suggested this fix which solved the issue. 

PUBLIC_DEMO_MODE=true triggers a code path in login/+page.svelte that references demoUsers, which is never declared — causes ReferenceError: demoUsers is not defined. Disabling until the demo map is implemented. Does not affect production/Pi compose files, which already default to PUBLIC_DEMO_MODE=false.