### PR TITLE
chore(scripts): provision fake-hwclock and chrony for clock stability (NEH-122)

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -116,13 +116,35 @@ fi
 # ---------------------------------------------------------------------------
 
 # gPhoto2
-if sudo apt install -y gphoto2
+if sudo apt install -y gphoto2; then
     echo "gPhoto2 package installed"
     echo ""
 else
     echo "gPhoto2 package not available in apt package manager."
     echo ""
 fi
+
+# ---------------------------------------------------------------------------
+# 6b. System clock hardening (survive power cuts without an RTC)
+# ---------------------------------------------------------------------------
+# Without a battery-backed clock the Pi resumes at the last saved tick after a
+# power cut, which scrambles capture timestamps. fake-hwclock persists the time
+# across reboots; chrony corrects it via NTP whenever the unit is online (such
+# as now, during setup).
+echo "→ Installing clock services (fake-hwclock, chrony)..."
+if sudo apt install -y fake-hwclock chrony; then
+    systemctl enable fake-hwclock 2>/dev/null || true
+    systemctl enable chrony 2>/dev/null || true
+    # Seed the saved clock now, while the time is correct
+    fake-hwclock save 2>/dev/null || true
+    echo "  fake-hwclock + chrony  ✓"
+else
+    echo "  clock services not available in apt — skipping"
+fi
+echo ""
+# Pi 5 hardware RTC (optional, done manually): fit a cell on the RTC header and
+# enable trickle charge by adding 'dtparam=rtc_bbat_vchg=3000000' to
+# /boot/firmware/config.txt, then 'sudo hwclock -w'.
 
 # ---------------------------------------------------------------------------
 # 7. Database initialisation & migrations


### PR DESCRIPTION
## What
Harden the appliance clock so capture order survives power cuts (part of NEH-122).

Without a battery-backed clock, the Pi resumes at the last saved tick after a power cut, which scrambles capture timestamps and (downstream) mass-expires session tokens.

## Changes
- `scripts/setup.sh`: install and enable **fake-hwclock** (persists the clock across reboots) and **chrony** (NTP correction while online), with an initial `fake-hwclock save` seed.
- Document the optional Pi 5 hardware RTC steps (battery header + trickle charge) as a manual note; no boot-config changes.

## Verification
Syntax-checked with `bash -n` only, as the provisioning itself needs the Pi (apt/systemd/RTC) and cannot be exercised on my dev machine (Windows).

Part of NEH-122. The capture-side fix (per-collection sequence + export order) ships separately in the backend PR.